### PR TITLE
feat: Remove `opening_time` and `closing_time` from `SalonBranch` mod…

### DIFF
--- a/_api_/migrations/0010_remove_branch_opening_closing_time.py
+++ b/_api_/migrations/0010_remove_branch_opening_closing_time.py
@@ -1,0 +1,20 @@
+# Generated migration to remove opening_time and closing_time from SalonBranch
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('_api_', '0009_vendorinvoice_coupon_points_used'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='salonbranch',
+            name='opening_time',
+        ),
+        migrations.RemoveField(
+            model_name='salonbranch',
+            name='closing_time',
+        ),
+    ]

--- a/_api_/models.py
+++ b/_api_/models.py
@@ -16,8 +16,6 @@ class SalonBranch(models.Model):
     admin_url = models.CharField(max_length=255)
     minimum_purchase_loyality = models.IntegerField(default=40, null=True)
     address = models.CharField(max_length=255, null=True, blank=True)
-    opening_time = models.TimeField(null=True, blank=True)
-    closing_time = models.TimeField(null=True, blank=True)
     class Meta:
         ordering = ['vendor_name']
         verbose_name = "Vendor Branch"

--- a/_api_/views.py
+++ b/_api_/views.py
@@ -1066,8 +1066,6 @@ class edit_branch(APIView):
         queryset.admin_password = accept_json_stream.get('admin_password')
         queryset.staff_url = accept_json_stream.get('staff_url')
         queryset.admin_url = accept_json_stream.get('admin_url')
-        queryset.opening_time = accept_json_stream.get('opening_time')
-        queryset.closing_time = accept_json_stream.get('closing_time')
         queryset.vendor_name = request.user
         queryset.save()
 


### PR DESCRIPTION
This pull request updates how salon branch operating hours are managed and validated. Instead of storing and checking `opening_time` and `closing_time` on the `SalonBranch` model, the code now relies on staff attendance times (`StaffAttendanceTime`) for validating booking times. This involves removing the old fields and updating serializers, views, and validation logic accordingly.

**Model and Database Changes**
- Removed the `opening_time` and `closing_time` fields from the `SalonBranch` model and database schema, including deleting them from the model definition, migrations, and all related serializers and views. [[1]](diffhunk://#diff-93b3121b108cb6a2b70905f13ecab9e65a7a39fee057c30176760461fcf2f4eeR1-R20) [[2]](diffhunk://#diff-8f2d91f71d54e282cfad408bac1e32411626a47babeee905e10322dc6fdba4e2L19-L20) [[3]](diffhunk://#diff-0a0752fee8d33dba1b4bdeca5c09dc3e341ee6a425ce3890e82340bb747b867cL1016-R1040) [[4]](diffhunk://#diff-ca41ec75dbfce268b118618ba27c63ae9cba07b799d1189ee68f1ce9d7a71663L1069-L1070)

**Booking Time Validation Logic**
- Updated the booking validation logic in the serializer to use `StaffAttendanceTime.in_time` and `StaffAttendanceTime.out_time` for checking if a booking is within working hours, instead of the removed branch opening/closing times. [[1]](diffhunk://#diff-0a0752fee8d33dba1b4bdeca5c09dc3e341ee6a425ce3890e82340bb747b867cR588-R599) [[2]](diffhunk://#diff-0a0752fee8d33dba1b4bdeca5c09dc3e341ee6a425ce3890e82340bb747b867cL603-R622) [[3]](diffhunk://#diff-0a0752fee8d33dba1b4bdeca5c09dc3e341ee6a425ce3890e82340bb747b867cL646-R667) [[4]](diffhunk://#diff-0a0752fee8d33dba1b4bdeca5c09dc3e341ee6a425ce3890e82340bb747b867cL661-R690)
- Improved error handling and time parsing for staff attendance times, ensuring bookings are only validated if staff times are properly configured and formatted. [[1]](diffhunk://#diff-0a0752fee8d33dba1b4bdeca5c09dc3e341ee6a425ce3890e82340bb747b867cL603-R622) [[2]](diffhunk://#diff-0a0752fee8d33dba1b4bdeca5c09dc3e341ee6a425ce3890e82340bb747b867cL661-R690)…el, shifting booking time validation to `StaffAttendanceTime`.